### PR TITLE
feat: add masonry layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,7 +30,7 @@
     max-height: calc(100vh - 100px); /* 视口高度减去到顶部的距离 */
     /* 上下滚动条 */
     overflow-y: auto;
-
+    column-count: 3;
 }
 
 .vertical-line {

--- a/src/card/Card.css
+++ b/src/card/Card.css
@@ -6,6 +6,7 @@
     margin-left: 5px;
     margin-right: 5px;
     margin-top: 10px;
+    break-inside: avoid;
 }
 
 .card:hover {


### PR DESCRIPTION
This layout uses CSS’s multi-column layout (column-count) to simulate a Masonry-like effect. Specifically, the page content is divided into 3 columns (column-count: 3;), and each element is prevented from being split between columns (achieved via break-inside: avoid;), ensuring that each item is fully displayed in the same column. This allows for a simple layout with uneven heights, suitable for a waterfall-style display.

Although this method does not provide the intelligent column height balancing of a true Masonry layout, it quickly achieves a similar visual effect without the need for JavaScript. This approach doesn't involve complex rearrangement of dynamic content but instead ensures orderly content flow through multiple columns, simplifying the layout implementation.

